### PR TITLE
Add Dockerfile for Glama MCP server checks

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,5 @@
+# Keep the build context small and force a clean rebuild of dist/.
+**/node_modules
+**/dist
+apps
+.git

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,44 @@
+# syntax=docker/dockerfile:1
+
+# ─── Build stage ─────────────────────────────────────────────────────────────
+# Builds only the three workspace packages the MCP server needs, in dependency
+# order (platform → api → mcp). Deliberately skips apps/* (Electron/Monaco),
+# which the MCP server does not use — keeps the build small and reliable.
+FROM node:22-bookworm-slim AS build
+WORKDIR /app
+
+# CI=true turns each package's `prepare` script into a no-op, so `npm install`
+# never triggers an out-of-order build. We build explicitly, in order, below.
+ENV CI=true
+
+# Minimal workspace root — only packages/*, never apps/*.
+RUN printf '{"name":"rds-mcp-build","private":true,"workspaces":["packages/*"]}\n' > package.json
+
+# Each package's tsconfig extends ../../tsconfig.base.json.
+COPY tsconfig.base.json ./
+
+# Only the three packages in the dependency graph.
+COPY packages/roku-dev-studio-platform/ packages/roku-dev-studio-platform/
+COPY packages/roku-dev-studio-api/       packages/roku-dev-studio-api/
+COPY packages/roku-dev-studio-mcp/       packages/roku-dev-studio-mcp/
+
+# Installs deps for all three workspaces; inter-workspace deps link locally.
+RUN npm install
+
+# esbuild bundles api + platform (and the prose .md files) into a single,
+# self-contained dist/index.cjs for the MCP server.
+RUN npm run build --workspace roku-dev-studio-platform \
+ && npm run build --workspace roku-dev-studio-api \
+ && npm run build --workspace roku-dev-studio-mcp
+
+# ─── Runtime stage ───────────────────────────────────────────────────────────
+# The bundle inlines every dependency, so the runtime image needs nothing but
+# Node and the single .cjs file.
+FROM node:22-bookworm-slim AS runtime
+WORKDIR /app
+COPY --from=build /app/packages/roku-dev-studio-mcp/dist/index.cjs ./index.cjs
+
+# Speaks MCP (JSON-RPC 2.0) over stdio. Glama's introspection driver connects
+# here; initialize / tools|resources|prompts.list are answered with no Roku
+# device, desktop app, or bridge socket present.
+ENTRYPOINT ["node", "/app/index.cjs"]


### PR DESCRIPTION
## What
Adds a root `Dockerfile` (and `.dockerignore`) that builds the `roku-dev-studio-mcp` server so [Glama](https://glama.ai/mcp/servers/paramount-engineering/roku-dev-studio) can build it and run its introspection checks.

## Why
The `glama-check` bot on the [awesome-mcp-servers PR](https://github.com/punkpeye/awesome-mcp-servers/pull/10653) requires the server to be listed on Glama and pass checks (build + start + respond to introspection) before the score badge populates. Glama needs a Dockerfile to do that. Our badge is already added to the awesome-mcp-servers entry; this unblocks the Glama build so the score renders.

## How it works
Multi-stage build:
- **build stage** — synthesizes a minimal `packages/*`-only workspace root (deliberately skips `apps/*` / Electron / Monaco, which the MCP server doesn't use), then builds the three packages in dependency order: `platform` → `api` → `mcp`. `ENV CI=true` no-ops each package's guarded `prepare` script so there's no out-of-order build; `tsconfig.base.json` is copied because every package extends it.
- **runtime stage** — carries only the self-contained esbuild bundle `dist/index.cjs` and runs it with Node.

## Verification
The server answers a full introspection handshake (`initialize`, `tools/list`, `resources/list`, `prompts/list` → 36 tools / 4 resources / 3 prompts) over stdio with **no Roku device, desktop app, or bridge socket** present — the bridge only connects on `tools/call`, which Glama's check does not invoke. Note: a live `docker build` wasn't run (Docker unavailable in the authoring environment); the build steps mirror the repo's existing per-package build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)