### PR TITLE
Fix LICENSE so GitHub/Glama detect it as MIT

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,7 +1,6 @@
 MIT License
 
-Copyright (c) 2026 Paramount Streaming
-Author: Hareendra Donapati
+Copyright (c) 2026 Paramount Streaming (Hareendra Donapati)
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@
 ![Version](https://img.shields.io/github/package-json/v/paramount-engineering/roku-dev-studio?filename=apps%2Froku-dev-studio%2Fpackage.json&label=version&color=purple)
 ![Electron](https://img.shields.io/github/package-json/dependency-version/paramount-engineering/roku-dev-studio/dev/electron?filename=apps%2Froku-dev-studio%2Fpackage.json&color=green)
 ![License](https://img.shields.io/badge/license-MIT-lightgrey)
+[![roku-dev-studio MCP server](https://glama.ai/mcp/servers/paramount-engineering/roku-dev-studio/badges/score.svg)](https://glama.ai/mcp/servers/paramount-engineering/roku-dev-studio)
 
 A comprehensive cross-platform desktop application for controlling and developing on Roku devices over your local network or via remote server using the External Control Protocol (ECP).
 

--- a/packages/roku-dev-studio-api/LICENSE
+++ b/packages/roku-dev-studio-api/LICENSE
@@ -1,7 +1,6 @@
 MIT License
 
-Copyright (c) 2026 Paramount Streaming
-Author: Hareendra Donapati
+Copyright (c) 2026 Paramount Streaming (Hareendra Donapati)
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/packages/roku-dev-studio-remote-server/LICENSE
+++ b/packages/roku-dev-studio-remote-server/LICENSE
@@ -1,7 +1,6 @@
 MIT License
 
-Copyright (c) 2026 Paramount Streaming
-Author: Hareendra Donapati
+Copyright (c) 2026 Paramount Streaming (Hareendra Donapati)
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal


### PR DESCRIPTION
## What
Folds the author attribution into the copyright line across all three `LICENSE` files (root + the two publishable packages), removing the standalone `Author:` line:

```
- Copyright (c) 2026 Paramount Streaming
- Author: Hareendra Donapati
+ Copyright (c) 2026 Paramount Streaming (Hareendra Donapati)
```

## Why
GitHub's license detector (`licensee`) currently classifies this repo as **"Other," not MIT** — confirmed via the API:
```
licenseInfo: { key: "other", name: "Other" }
```
The cause is the non-standard `Author: Hareendra Donapati` line inserted into the MIT template body, which breaks template matching. `licensee` tolerates arbitrary text on the copyright line but not an extra line in the body, so folding the name into the copyright line keeps the attribution while restoring a clean MIT match.

## Impact
Once merged, GitHub re-detects the repo as MIT, and [Glama](https://glama.ai/mcp/servers/paramount-engineering/roku-dev-studio) then auto-detects it (within a few hours, or via a manual re-scan). This clears the **license = F** finding and the **"MCP servers without a LICENSE cannot be installed"** block on the Glama listing.

Files: `LICENSE`, `packages/roku-dev-studio-api/LICENSE`, `packages/roku-dev-studio-remote-server/LICENSE`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)