### PR TITLE
fix(errors): suppress benign ResizeObserver warning from crash modal

### DIFF
--- a/apps/roku-dev-studio/renderer/modules/errors/crash-report.ts
+++ b/apps/roku-dev-studio/renderer/modules/errors/crash-report.ts
@@ -22,9 +22,17 @@ export type AppInfo = {
 
 const shownSignatures = new Set<string>();
 
+/** Browser-internal warnings delivered via window.onerror that never indicate an actual bug —
+ *  Chromium's ResizeObserver notification batching, not a real infinite loop or crash. */
+const BENIGN_MESSAGES = new Set<string>([
+  'ResizeObserver loop completed with undelivered notifications.',
+  'ResizeObserver loop limit exceeded'
+]);
+
 /** True the first time this exact message+stack is seen this session; marks it seen either way.
  *  Keeps a looping error from reopening the modal on every occurrence. */
 export function shouldShowModalFor(err: CapturedError): boolean {
+  if (BENIGN_MESSAGES.has(err.message)) return false;
   const signature = `${err.message}::${err.stack}`;
   if (shownSignatures.has(signature)) return false;
   shownSignatures.add(signature);


### PR DESCRIPTION
## Summary
- The crash-report modal was popping up for `ResizeObserver loop completed with undelivered notifications.`, a benign Chromium warning (notification batching, not a real infinite loop or crash) — reproduced in the log-file-viewer window per the linked issue.
- `shouldShowModalFor` in `crash-report.ts` now filters this and the related `ResizeObserver loop limit exceeded` message before showing the modal. It's fixed at the shared choke point every window's `error`/`unhandledrejection` listener funnels through (`install.ts`), so it's suppressed everywhere, not just log-file-viewer.

Fixes #66

## Test plan
- [ ] Open the log file viewer with a large log file and confirm no crash modal appears from ResizeObserver noise
- [ ] Confirm real renderer errors still trigger the crash modal (dedup/signature logic untouched)
- [ ] `npm run typecheck`

🤖 Generated with [Claude Code](https://claude.com/claude-code)